### PR TITLE
Require version 2.011 for Dist::Zilla::Plugin::CompileTests

### DIFF
--- a/lib/Dist/Zilla/PluginBundle/Dancer.pm
+++ b/lib/Dist/Zilla/PluginBundle/Dancer.pm
@@ -54,7 +54,7 @@ use strict;
 use Moose;
 
 use Dist::Zilla::Plugin::GatherDir;
-use Dist::Zilla::Plugin::Test::Compile;
+use Dist::Zilla::Plugin::Test::Compile 2.011;
 use Dist::Zilla::Plugin::MetaTests;
 use Dist::Zilla::Plugin::NoTabsTests;
 use Dist::Zilla::Plugin::PodSyntaxTests;


### PR DESCRIPTION
The previous version of this module would try to compile .pod files and fail.
By requiring a newer version we can remove a hack from Dancer2's dist.init.

Closes #3
